### PR TITLE
Debugging example for webpack

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -18,7 +18,14 @@
     "webpack-cli": "^4.10.0"
   },
   "dependencies": {
+    "buffer": "^6.0.3",
     "compute-cosine-similarity": "^1.0.0",
-    "openai": "github:radu-matei/openai-node#without-axios"
+    "https-browserify": "^1.0.0",
+    "openai": "github:radu-matei/openai-node#without-axios",
+    "path-browserify": "^1.0.1",
+    "stream-browserify": "^3.0.0",
+    "stream-http": "^3.2.0",
+    "url": "^0.11.0",
+    "util": "^0.12.5"
   }
 }

--- a/api/webpack.config.js
+++ b/api/webpack.config.js
@@ -2,6 +2,7 @@ const path = require('path');
 
 module.exports = {
     entry: './src/index.ts',
+    target: 'es6',
     module: {
         rules: [
             {
@@ -11,13 +12,37 @@ module.exports = {
             },
         ],
     },
+    externalsType: 'global',
+    externals: {
+        "fetch": "fetch",
+        "fsPromises": "fsPromises",
+        "glob": "glob",
+        "crypto": "crypto",
+    },
     resolve: {
         extensions: ['.tsx', '.ts', '.js'],
+        fallback: {
+            // polyfills for nodejs modules
+            "url": require.resolve("url/"),
+            "util": require.resolve("util/"),
+            "buffer": require.resolve("buffer/"),
+            "path": require.resolve("path-browserify"),
+            "stream": require.resolve("stream-browserify"),
+            "https": require.resolve("https-browserify"),
+            "http": require.resolve("stream-http"),
+            // no polyfill for these
+            "fs": false,
+        },
     },
     output: {
         path: path.resolve(__dirname, 'dist'),
         filename: 'spin.js',
-        library: 'spin'
+        chunkFormat: 'module',
+        chunkLoading: 'import',
+        library: {
+            type: 'this',
+            name: 'spin',
+        },
     },
     optimization: {
         minimize: false

--- a/spin.toml
+++ b/spin.toml
@@ -16,6 +16,7 @@ route = "/..."
 id = "api"
 source = "api/target/api.wasm"
 key_value_stores = ["default"]
+allowed_http_hosts = [ "insecure:allow-all" ]
 [component.trigger]
 route = "/api"
 [component.build]


### PR DESCRIPTION
Debugging rabbit hole:
- openai's npm package was reporting a `window is not defined` error
- that error was coming from the `form-data` dependency in the `browser.js` file
- `browser.js` is specified as one of the target entrypoints in the `package.json` manifest under the `browser` field
- webpack defaults to using the `web` target and will prefer the `browser` entrypoint unless you change the target to something like `node` or `es6`
- changing the target to `node` resulted in `require` is undefined and I couldn't figure out a way around this
- changing the target to `es6` resulted in webpack not knowing how to resolve modules and failed to build
- adding `output.chunkFormat=module` and `output.chunkLoading=import` allowed webpack to resolve modules but still erroring with `Module not found: Error: Can't resolve 'fs' in ...`
- I started to look at the globals that the spin-js-sdk exports
- for all the SDK exported globals that matched up with a node.js standard library, I added them to `externals` and set the `externalType` to be `global`
- for all other node.js standard libraries, I attempted to polyfill them using other node packages
- ended up only needing to "ignore" the `fs` standard library package because I couldn't find a polyfill for that one